### PR TITLE
Add /auth/token endpoint to authenticate user.

### DIFF
--- a/atlas/urls.py
+++ b/atlas/urls.py
@@ -1,21 +1,16 @@
-"""atlas URL Configuration
+# *****************************************************************************
+# atlas/authentication/urls.py
+# *****************************************************************************
 
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/2.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
+from django.conf.urls import include, url
 from django.contrib import admin
-from django.urls import path
+from rest_framework_jwt.views import obtain_jwt_token
+
+# *****************************************************************************
+# urlpatterns
+# *****************************************************************************
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    url(r'admin/', admin.site.urls),
+    url(r'auth/token', obtain_jwt_token),
 ]


### PR DESCRIPTION
Closes issue #6.

Create bare-bones auth endpoint: `/auth/token`.
Requires payload of:
```
{"username": "<username>", "password": "<password>"}

Returns token:
{"token": "<token>"}

To test it out, please have Django running and go to `localhost:8000/auth/token`.