### PR TITLE
[Feature] Add endpoint filtering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django==2.2.13
 psycopg2==2.7.*
+django-filter==2.2.0
 django-cors-headers==2.4.0
 djangorestframework==3.8.1
 djangorestframework-jwt==1.8.0

--- a/supporters/filters.py
+++ b/supporters/filters.py
@@ -1,0 +1,55 @@
+# *****************************************************************************
+# supporters/filters.py
+# *****************************************************************************
+
+import django_filters
+
+from .models import Supporter
+
+# *****************************************************************************
+# SupporterFilter
+# *****************************************************************************
+
+
+class SupporterFilter(django_filters.FilterSet):
+
+    first_name = django_filters.CharFilter(
+        field_name='first_name',
+        lookup_expr='exact',
+    )
+    last_name = django_filters.CharFilter(
+        field_name='last_name',
+        lookup_expr='exact',
+    )
+    email = django_filters.CharFilter(
+        field_name='email',
+        lookup_expr='exact',
+    )
+    district_tag = django_filters.CharFilter(
+        field_name='address__district__tag',
+        lookup_expr='exact',
+    )
+    district_name = django_filters.CharFilter(
+        field_name='address__district__name',
+        lookup_expr='exact',
+    )
+    cause_tag = django_filters.CharFilter(
+        field_name='causes__tag',
+        lookup_expr='exact',
+    )
+    cause_name = django_filters.CharFilter(
+        field_name='causes__name',
+        lookup_expr='exact',
+    )
+
+    class Meta:
+        model = Supporter
+        fields = (
+            'first_name',
+            'last_name',
+            'email',
+            'district_tag',
+            'district_name',
+            'cause_tag',
+            'cause_name',
+        )

--- a/supporters/views.py
+++ b/supporters/views.py
@@ -2,6 +2,7 @@
 # supporters/views.py
 # *****************************************************************************
 
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, viewsets, mixins, permissions
 from rest_framework.response import Response
 
@@ -51,6 +52,7 @@ class SupporterViewSet(mixins.CreateModelMixin,
     """
 
     filter_backend = (
+        DjangoFilterBackend,
         filters.OrderingFilter,
         filters.SearchFilter
     )

--- a/supporters/views.py
+++ b/supporters/views.py
@@ -6,6 +6,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, viewsets, mixins, permissions
 from rest_framework.response import Response
 
+from .filters import SupporterFilter
 from .models import District, Supporter
 from .serializers import DistrictSerializer, SupporterSerializer
 
@@ -56,6 +57,7 @@ class SupporterViewSet(mixins.CreateModelMixin,
         filters.OrderingFilter,
         filters.SearchFilter
     )
+    filter_class = SupporterFilter
     ordering = ['-updated_on']
     ordering_fields = ['created_on', 'updated_on']
     permission_classes = [permissions.IsAuthenticated]

--- a/supporters/views.py
+++ b/supporters/views.py
@@ -25,7 +25,8 @@ class DistrictViewSet(mixins.CreateModelMixin,
 
     """
 
-    filter_backend = (
+    filter_backends = (
+        DjangoFilterBackend,
         filters.OrderingFilter,
         filters.SearchFilter
     )
@@ -52,7 +53,7 @@ class SupporterViewSet(mixins.CreateModelMixin,
 
     """
 
-    filter_backend = (
+    filter_backends = (
         DjangoFilterBackend,
         filters.OrderingFilter,
         filters.SearchFilter


### PR DESCRIPTION
#### What's this PR do?
Adds filtering capability to endpoints.
Filters can be applied to the supporters endpoint with the following query params:
- first_name
- last_name
- email
- district_tag
- district_name
- cause_tag
- cause_name

Examples: 
`localhost:8000/api/supporters/?first_name=Justin`
`localhost:8000/api/supporters/?first_name=Justin&cause_name=Police+Reform`
This will respond with a list of supporters that have the first_name equal to Justin.

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Questions:
